### PR TITLE
Add Commerce Shipping dependency to prevent silent errors or error messages when Shipping module is disabled

### DIFF
--- a/src/commerce_bitpay.info
+++ b/src/commerce_bitpay.info
@@ -3,6 +3,7 @@ description = Implements BitPay payment services for use with Drupal Commerce.
 package = Commerce (contrib)
 dependencies[] = commerce
 dependencies[] = commerce_payment
+dependencies[] = commerce_shipping
 core = 7.x
 configure = admin/settings/commerce-bitpay
 php = 5.4


### PR DESCRIPTION
Tests do not include enabling then disabling the Commerce Shipping module causing stored data to change BitPay module's behavior.

Please review carefully along with the other pull.